### PR TITLE
package license file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.13.0"
 authors = ["Zibi Braniecki <gandalf@mozilla.com>"]
 homepage = "http://projectfluent.org/"
 license = "Apache-2.0"
+license-file = "LICENSE"
 repository = "https://github.com/projectfluent/fluent-langneg-rs"
 readme = "README.md"
 categories = ["internationalization", "localization"]


### PR DESCRIPTION
Using this library by another crate it would be nice to have an easy way to extract the library's license file. Having a packaged license file no manual steps are needed to extract it from github.